### PR TITLE
Visualizing PPM from *csv

### DIFF
--- a/laravel/storage/app/services/7/CSVppm.py
+++ b/laravel/storage/app/services/7/CSVppm.py
@@ -1,5 +1,20 @@
+# /// script
+# requires-python = "==3.11.*"
+# dependencies = [
+#   "pybezierppm@git+https://github.com/Any2HRTF/PPM@cd8c224578808f5a729102068ceeed9d9ebe07dd", # pinning the commit we published the paper with and the functonality is assured
+# ]
+# ///
+
+import argparse
 from bezierppm import BezierPPM
-    # path to the CSV file needs to be defined
-ppm = BezierPPM(from_csv='path/to/file.csv')
-    # path of the output file needs to be defined
-ppm.export_stl('path/to/file_1.stl')
+def main(args):
+    ppm = BezierPPM(from_csv_file=args.input)
+    ppm.export_stl(f'{args.input}_1.stl')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--input", type=str, help="Path to the csv file with the PPM parameters.")
+
+    main(parser.parse_args())
+

--- a/laravel/storage/app/services/7/CSVppm.py
+++ b/laravel/storage/app/services/7/CSVppm.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = "==3.11.*"
 # dependencies = [
@@ -7,14 +8,18 @@
 
 import argparse
 from bezierppm import BezierPPM
+
+
 def main(args):
     ppm = BezierPPM(from_csv_file=args.input)
-    ppm.export_stl(f'{args.input}_1.stl')
+    ppm.export_stl(f"{args.input}_1.stl")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--input", type=str, help="Path to the csv file with the PPM parameters.")
+    parser.add_argument(
+        "--input", type=str, help="Path to the csv file with the PPM parameters."
+    )
 
     main(parser.parse_args())
-


### PR DESCRIPTION
now working
I use uv which is nice since you can define the required python version and packages. Additionally it is nice to make the file executable `chmod +x /path/to/file.py`. Now given uv is installed one would run `laravel/storage/app/services/7/CSVppm.py --input /Users/fancyuser/path/to/stl/PPM.csv`. if forever reason you don't want the file to be executable it is also possible to run `uv run laravel/storage/app/services/7/CSVppm.py --input /Users/fancyuser/path/to/stl/PPM.csv`. Additionally if you don't want to install uv the correct python version and the package must be installed and called. 